### PR TITLE
upd readme+upprovider+nextjs version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A template project demonstrating how to build mini-apps using the [up-provider p
 ## Overview
 
 This template showcases:
+
 - [UP-Provider](https://github.com/lukso-network/tools-up-provider) implementation and wallet connection on the Grid
 - Profile search functionality using Envio integration for fast querying
 - Integrates the [@lukso/web-components](https://www.npmjs.com/package/@lukso/web-components) library for ready-to-use branded components
@@ -15,56 +16,53 @@ This template showcases:
 ## Key Features
 
 ### UP-Provider Integration
+
 The template demonstrates how to:
+
 - Connect to Universal Profile browser extension from the Grid
 - Manage UP contexts on the Grid
 
 ### Envio Integration
+
 Shows how to:
+
 - Query the LUKSO Envio indexer
 - Search for Universal Profiles
 - Display profile information and images
 
 ### Web Components
+
 Shows how to:
+
 - Use the [@lukso/web-components](https://www.npmjs.com/package/@lukso/web-components) library to display profile card
 
 ### ERC-725.js
+
 Shows how to:
+
 - Use the [erc725js](https://docs.lukso.tech/tools/dapps/erc725js/getting-started) library to fetch profile data from the blockchain
 
 ## Getting Started
 
 1. Install dependencies:
+
 ```bash
 yarn install
 ```
+
 2. Run the development server:
+
 ```bash
 yarn dev
 ```
 
-3. Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.(Note that the Grid context is not available in the local environment)
+3. Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 4. Testing your mini-app on the Grid:
 
-We're using `localtunnel` to test the mini-app on the Grid. This library helps us to generate a public URL that can be used to add the mini-app to the Grid.
+Simply add your localhost url as a mini-app to your Grid!
 
-> Alternatively, you can use free cloud deployment services like Vercel, Replit, etc.
-
-Globally install `localtunnel`: 
-
-```bash
-npm install -g localtunnel
-```
-
-In the second terminal, run:
-
-```bash
-lt --port <LOCALHOST_PORT>
-```
-
-You can use this URL to add the mini-app to the Grid. 
+> Alternatively, you can use free cloud deployment services like Vercel, Replit, etc. and use the url provided from those services.
 
 ## Project Structure
 
@@ -77,9 +75,8 @@ You can use this URL to add the mini-app to the Grid.
 
 - [LUKSO Documentation](https://docs.lukso.tech/) - Learn more about developing on LUKSO
 - [UP Browser Extension](https://docs.lukso.tech/install-up-browser-extension) - Install the Universal Profile Browser Extension
-- [erc725js](https://docs.lukso.tech/tools/dapps/erc725js/getting-started) - Learn more about the erc725js library 
+- [erc725js](https://docs.lukso.tech/tools/dapps/erc725js/getting-started) - Learn more about the erc725js library
 - [@lukso/web-components](https://www.npmjs.com/package/@lukso/web-components) - Learn more about the @lukso/web-components library
-
 
 ## Contributing
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,7 +6,7 @@ const nextConfig: NextConfig = {
     quietDeps: true,
   },
   images: {
-    domains: ['api.universalprofile.cloud']
+    remotePatterns: [{ hostname: 'api.universalprofile.cloud' }],
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
   },
   "dependencies": {
     "@erc725/erc725.js": "^0.27.2",
-    "@lukso/up-provider": "^0.3.2",
+    "@lukso/up-provider": "^0.3.5",
     "@lukso/web-components": "^1.104.0",
     "@radix-ui/react-slot": "^1.1.0",
     "class-variance-authority": "^0.7.1",
     "ethereum-blockies-base64": "^1.0.2",
     "graphql": "^16.10.0",
     "graphql-request": "^7.1.2",
-    "next": "15.1.0",
+    "next": "15.2.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "viem": "^2.21.54"

--- a/yarn.lock
+++ b/yarn.lock
@@ -516,9 +516,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lukso/up-provider@npm:^0.3.2":
-  version: 0.3.2
-  resolution: "@lukso/up-provider@npm:0.3.2"
+"@lukso/up-provider@npm:^0.3.5":
+  version: 0.3.5
+  resolution: "@lukso/up-provider@npm:0.3.5"
   dependencies:
     "@mixer/postmessage-rpc": "npm:^1.1.4"
     "@types/debug": "npm:^4.1.12"
@@ -529,7 +529,7 @@ __metadata:
     lit: "npm:^3.2.1"
     pauseable: "npm:^0.3.2"
     uuid: "npm:^11.0.3"
-  checksum: 10c0/20adb3c0f910a671a1755617b0df7399c76398d4056747c8cd10b1b9ced41de78192d5a650d30039097b606fd40e71afd6a9a0536625b58d0e73d712c4a79611
+  checksum: 10c0/ac91857bea2e68dc4840e710cd34f4fc7b7731ffea18269cf410484dac232a671126115bac4fa410be0e9c31a98b2727c23e97c564ffc6e53b909038cf70b3a4
   languageName: node
   linkType: hard
 
@@ -570,10 +570,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:15.1.0":
-  version: 15.1.0
-  resolution: "@next/env@npm:15.1.0"
-  checksum: 10c0/5c6d66bcc652696a8dbbe1596194b612dd492e8b27041b738fcb63aa08669754bd7bdd3664ec8b756029a7d7b22187e646409fc1651c5e95d3ae39c3cca62c3d
+"@next/env@npm:15.2.3":
+  version: 15.2.3
+  resolution: "@next/env@npm:15.2.3"
+  checksum: 10c0/52e60419f71b991bdab23fc23f05d221dfe07b725140a110eedc158b2612cebcaa71a74726e2f78b1d53ae162ae0a745fdc3263a2bc76eda013cac057a30f05e
   languageName: node
   linkType: hard
 
@@ -586,58 +586,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:15.1.0":
-  version: 15.1.0
-  resolution: "@next/swc-darwin-arm64@npm:15.1.0"
+"@next/swc-darwin-arm64@npm:15.2.3":
+  version: 15.2.3
+  resolution: "@next/swc-darwin-arm64@npm:15.2.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:15.1.0":
-  version: 15.1.0
-  resolution: "@next/swc-darwin-x64@npm:15.1.0"
+"@next/swc-darwin-x64@npm:15.2.3":
+  version: 15.2.3
+  resolution: "@next/swc-darwin-x64@npm:15.2.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:15.1.0":
-  version: 15.1.0
-  resolution: "@next/swc-linux-arm64-gnu@npm:15.1.0"
+"@next/swc-linux-arm64-gnu@npm:15.2.3":
+  version: 15.2.3
+  resolution: "@next/swc-linux-arm64-gnu@npm:15.2.3"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:15.1.0":
-  version: 15.1.0
-  resolution: "@next/swc-linux-arm64-musl@npm:15.1.0"
+"@next/swc-linux-arm64-musl@npm:15.2.3":
+  version: 15.2.3
+  resolution: "@next/swc-linux-arm64-musl@npm:15.2.3"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:15.1.0":
-  version: 15.1.0
-  resolution: "@next/swc-linux-x64-gnu@npm:15.1.0"
+"@next/swc-linux-x64-gnu@npm:15.2.3":
+  version: 15.2.3
+  resolution: "@next/swc-linux-x64-gnu@npm:15.2.3"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:15.1.0":
-  version: 15.1.0
-  resolution: "@next/swc-linux-x64-musl@npm:15.1.0"
+"@next/swc-linux-x64-musl@npm:15.2.3":
+  version: 15.2.3
+  resolution: "@next/swc-linux-x64-musl@npm:15.2.3"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:15.1.0":
-  version: 15.1.0
-  resolution: "@next/swc-win32-arm64-msvc@npm:15.1.0"
+"@next/swc-win32-arm64-msvc@npm:15.2.3":
+  version: 15.2.3
+  resolution: "@next/swc-win32-arm64-msvc@npm:15.2.3"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:15.1.0":
-  version: 15.1.0
-  resolution: "@next/swc-win32-x64-msvc@npm:15.1.0"
+"@next/swc-win32-x64-msvc@npm:15.2.3":
+  version: 15.2.3
+  resolution: "@next/swc-win32-x64-msvc@npm:15.2.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -2843,7 +2843,7 @@ __metadata:
   dependencies:
     "@erc725/erc725.js": "npm:^0.27.2"
     "@eslint/eslintrc": "npm:^3"
-    "@lukso/up-provider": "npm:^0.3.2"
+    "@lukso/up-provider": "npm:^0.3.5"
     "@lukso/web-components": "npm:^1.104.0"
     "@radix-ui/react-slot": "npm:^1.1.0"
     "@types/node": "npm:^20"
@@ -2855,7 +2855,7 @@ __metadata:
     ethereum-blockies-base64: "npm:^1.0.2"
     graphql: "npm:^16.10.0"
     graphql-request: "npm:^7.1.2"
-    next: "npm:15.1.0"
+    next: "npm:15.2.3"
     postcss: "npm:^8"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
@@ -3794,19 +3794,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:15.1.0":
-  version: 15.1.0
-  resolution: "next@npm:15.1.0"
+"next@npm:15.2.3":
+  version: 15.2.3
+  resolution: "next@npm:15.2.3"
   dependencies:
-    "@next/env": "npm:15.1.0"
-    "@next/swc-darwin-arm64": "npm:15.1.0"
-    "@next/swc-darwin-x64": "npm:15.1.0"
-    "@next/swc-linux-arm64-gnu": "npm:15.1.0"
-    "@next/swc-linux-arm64-musl": "npm:15.1.0"
-    "@next/swc-linux-x64-gnu": "npm:15.1.0"
-    "@next/swc-linux-x64-musl": "npm:15.1.0"
-    "@next/swc-win32-arm64-msvc": "npm:15.1.0"
-    "@next/swc-win32-x64-msvc": "npm:15.1.0"
+    "@next/env": "npm:15.2.3"
+    "@next/swc-darwin-arm64": "npm:15.2.3"
+    "@next/swc-darwin-x64": "npm:15.2.3"
+    "@next/swc-linux-arm64-gnu": "npm:15.2.3"
+    "@next/swc-linux-arm64-musl": "npm:15.2.3"
+    "@next/swc-linux-x64-gnu": "npm:15.2.3"
+    "@next/swc-linux-x64-musl": "npm:15.2.3"
+    "@next/swc-win32-arm64-msvc": "npm:15.2.3"
+    "@next/swc-win32-x64-msvc": "npm:15.2.3"
     "@swc/counter": "npm:0.1.3"
     "@swc/helpers": "npm:0.5.15"
     busboy: "npm:1.6.0"
@@ -3851,7 +3851,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 10c0/652a48a6cf6329753da72bec9777c153e88aee8dd1bb709c2c8e6b31b678514d50501e1a58e065464416998bb5d872ce0eaf769e7aacebc2821d36359e63c225
+  checksum: 10c0/d9f374d42e422b1fc6ef3499e46318b572717c4dd35db04c25bec3b998e693d927ec8edaa7aa819f71aae7ae74645f498184e08ad261e35baeeaac560e915b9c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR updates the readme file as it is now possible to use localhost URL on the grid for testing your miniapp

And it bumps the upprovider & nextjs versions 